### PR TITLE
fix: changing some requirements

### DIFF
--- a/src/main/java/acme/features/manager/flight/FlightCreateService.java
+++ b/src/main/java/acme/features/manager/flight/FlightCreateService.java
@@ -49,9 +49,6 @@ public class FlightCreateService extends AbstractGuiService<Manager, Flight> {
 
 	@Override
 	public void validate(final Flight flight) {
-		boolean confirmation;
-		confirmation = super.getRequest().getData("confirmation", boolean.class);
-		super.state(confirmation, "confirmation", "acme.validation.confirmation.message");
 	}
 
 	@Override

--- a/src/main/java/acme/features/manager/flight/FlightPublishService.java
+++ b/src/main/java/acme/features/manager/flight/FlightPublishService.java
@@ -74,25 +74,6 @@ public class FlightPublishService extends AbstractGuiService<Manager, Flight> {
 		boolean allLegsPublished = legs.stream().allMatch(leg -> !leg.getDraftMode());
 		super.state(allLegsPublished, "*", "acme.validation.flight.legs-not-published.message");
 
-		// R4: casilla de confirmación
-		boolean confirmation = super.getRequest().getData("confirmation", boolean.class);
-		super.state(confirmation, "confirmation", "acme.validation.confirmation.message");
-
-		//R5: si hay legs publicados y los aeropuertos no son consecutivos, no se puede modificar el atributo selfTransfer
-		Collection<Leg> publishedLegs = this.legRepository.findPublishedLegsByFlightId(flight.getId());
-		if (!flight.getSelfTransfer() && publishedLegs.size() > 1) {
-			boolean airportsAreConsecutive = true;
-			Leg previous = null;
-			for (Leg current : publishedLegs) {
-				if (previous != null)
-					if (!previous.getArrivalAirport().equals(current.getDepartureAirport())) {
-						airportsAreConsecutive = false;
-						break;
-					}
-				previous = current;
-			}
-			super.state(airportsAreConsecutive, "*", "acme.validation.flight.selfTransfer-legs-not-consecutive.message");
-		}
 	}
 
 	@Override

--- a/src/main/java/acme/features/manager/flight/FlightUpdateService.java
+++ b/src/main/java/acme/features/manager/flight/FlightUpdateService.java
@@ -1,15 +1,12 @@
 
 package acme.features.manager.flight;
 
-import java.util.Collection;
-
 import org.springframework.beans.factory.annotation.Autowired;
 
 import acme.client.components.models.Dataset;
 import acme.client.services.AbstractGuiService;
 import acme.client.services.GuiService;
 import acme.entities.flight.Flight;
-import acme.entities.leg.Leg;
 import acme.features.manager.leg.LegRepository;
 import acme.realms.manager.Manager;
 
@@ -65,29 +62,10 @@ public class FlightUpdateService extends AbstractGuiService<Manager, Flight> {
 	@Override
 	public void validate(final Flight flight) {
 		boolean isDraftMode;
-		boolean confirmation;
 
 		isDraftMode = flight.getDraftMode();
-		confirmation = super.getRequest().getData("confirmation", boolean.class);
-
-		//R5: si hay legs publicados y los aeropuertos no son consecutivos, no se puede modificar el atributo selfTransfer
-		Collection<Leg> publishedLegs = this.legRepository.findPublishedLegsByFlightId(flight.getId());
-		if (!flight.getSelfTransfer() && publishedLegs.size() > 1) {
-			boolean airportsAreConsecutive = true;
-			Leg previous = null;
-			for (Leg current : publishedLegs) {
-				if (previous != null)
-					if (!previous.getArrivalAirport().equals(current.getDepartureAirport())) {
-						airportsAreConsecutive = false;
-						break;
-					}
-				previous = current;
-			}
-			super.state(airportsAreConsecutive, "*", "acme.validation.flight.selfTransfer-legs-not-consecutive.message");
-		}
 
 		super.state(isDraftMode, "*", "acme.validation.flight.draftMode.updated.message");
-		super.state(confirmation, "confirmation", "acme.validation.confirmation.message");
 	}
 
 	@Override

--- a/src/main/resources/WEB-INF/views/manager/flight/form.jsp
+++ b/src/main/resources/WEB-INF/views/manager/flight/form.jsp
@@ -13,7 +13,6 @@
 	<jstl:choose>
 		<jstl:when test="${acme:anyOf(_command, 'show|update|delete|publish')}">
 		<jstl:if test="${flightDraftMode}">
-			<acme:input-checkbox path="confirmation" code="manager.flight.form.label.confirmation"/>
 			<acme:submit code="manager.flight.form.button.update" action="/manager/flight/update"/>
 			<acme:submit code="manager.flight.form.button.delete" action="/manager/flight/delete"/>
 			<acme:submit code="manager.flight.form.button.publish" action="/manager/flight/publish"/>
@@ -21,7 +20,6 @@
 			<acme:button code="manager.flight.form.button.legs" action="/manager/leg/list?flightId=${id}"/>
 		</jstl:when>
 		<jstl:when test="${_command == 'create'}">
-			<acme:input-checkbox path="confirmation" code="manager.flight.form.label.confirmation"/>
 			<acme:submit code="manager.flight.form.button.create" action="/manager/flight/create"/>
 		</jstl:when>
 	</jstl:choose>


### PR DESCRIPTION
now create, update and publish flights not requires confirmation. selfTransfer atribute can be changed even if airports are not consecutive and legs are published

CLOSES #562 